### PR TITLE
DefaultIndexLocation: Solus instead of Unstable

### DIFF
--- a/cli/constants.go
+++ b/cli/constants.go
@@ -19,7 +19,7 @@ package cli
 // Paths
 const (
 	DefaultDBLocation    = "/.cache/eopkg-deps.db"
-	DefaultIndexLocation = "/var/lib/eopkg/index/Unstable/eopkg-index.xml"
+	DefaultIndexLocation = "/var/lib/eopkg/index/Solus/eopkg-index.xml"
 )
 
 // Error Strings


### PR DESCRIPTION
Because @JoshStrobl set Solus as default repo name ;)